### PR TITLE
overwrite base/test/fixtures/issues.yml since issues.position NOT NULL

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -42,6 +42,8 @@ Rails.configuration.to_prepare do
   require_dependency 'linear_regression'
 
   Redmine::AccessControl.permission(:manage_versions).actions << "rb_sprints/close_completed"
+
+  FileUtils.cp(File.dirname(__FILE__) + '/test/fixtures/issues.yml', Rails.root + 'test/fixtures/')
 end
 
 
@@ -49,7 +51,7 @@ Redmine::Plugin.register :redmine_backlogs do
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.2.5'
+  version 'v1.2.6'
 
   settings :default => {
                          :story_trackers            => nil,

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -1,0 +1,288 @@
+# follow 'issues' table 'position' column become null=>false
+
+---
+issues_001:
+  position: 0
+  created_on: <%= 3.days.ago.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 1.day.ago.to_s(:db) %>
+  priority_id: 4
+  subject: Cannot print recipes
+  id: 1
+  fixed_version_id:
+  category_id: 1
+  description: Unable to print recipes
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  start_date: <%= 1.day.ago.to_date.to_s(:db) %>
+  due_date: <%= 10.day.from_now.to_date.to_s(:db) %>
+  estimated_hours: 200.0
+  root_id: 1
+  lft: 1
+  rgt: 2
+  lock_version: 3
+issues_002:
+  position: 0
+  created_on: 2006-07-19 21:04:21 +02:00
+  project_id: 1
+  updated_on: 2006-07-19 21:09:50 +02:00
+  priority_id: 5
+  subject: Add ingredients categories
+  id: 2
+  fixed_version_id: 2
+  category_id:
+  description: Ingredients of the recipe should be classified by categories
+  tracker_id: 2
+  assigned_to_id: 3
+  author_id: 2
+  status_id: 2
+  start_date: <%= 2.day.ago.to_date.to_s(:db) %>
+  due_date:
+  estimated_hours: 0.5
+  root_id: 2
+  lft: 1
+  rgt: 2
+  lock_version: 3
+  done_ratio: 30
+issues_003:
+  position: 0
+  created_on: 2006-07-19 21:07:27 +02:00
+  project_id: 1
+  updated_on: 2006-07-19 21:07:27 +02:00
+  priority_id: 4
+  subject: Error 281 when updating a recipe
+  id: 3
+  fixed_version_id:
+  category_id:
+  description: Error 281 is encountered when saving a recipe
+  tracker_id: 1
+  assigned_to_id: 3
+  author_id: 2
+  status_id: 1
+  start_date: <%= 15.day.ago.to_date.to_s(:db) %>
+  due_date: <%= 5.day.ago.to_date.to_s(:db) %>
+  estimated_hours: 1.0
+  root_id: 3
+  lft: 1
+  rgt: 2
+issues_004:
+  position: 0
+  created_on: <%= 5.days.ago.to_s(:db) %>
+  project_id: 2
+  updated_on: <%= 2.days.ago.to_s(:db) %>
+  priority_id: 4
+  subject: Issue on project 2
+  id: 4
+  fixed_version_id:
+  category_id:
+  description: Issue on project 2
+  tracker_id: 1
+  assigned_to_id: 2
+  author_id: 2
+  status_id: 1
+  root_id: 4
+  lft: 1
+  rgt: 2
+issues_005:
+  position: 0
+  created_on: <%= 5.days.ago.to_s(:db) %>
+  project_id: 3
+  updated_on: <%= 2.days.ago.to_s(:db) %>
+  priority_id: 4
+  subject: Subproject issue
+  id: 5
+  fixed_version_id:
+  category_id:
+  description: This is an issue on a cookbook subproject
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  estimated_hours: 2.0
+  root_id: 5
+  lft: 1
+  rgt: 2
+issues_006:
+  position: 0
+  created_on: <%= 1.minute.ago.to_s(:db) %>
+  project_id: 5
+  updated_on: <%= 1.minute.ago.to_s(:db) %>
+  priority_id: 4
+  subject: Issue of a private subproject
+  id: 6
+  fixed_version_id:
+  category_id:
+  description: This is an issue of a private subproject of cookbook
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  start_date: <%= Date.today.to_s(:db) %>
+  due_date: <%= 1.days.from_now.to_date.to_s(:db) %>
+  root_id: 6
+  lft: 1
+  rgt: 2
+issues_007:
+  position: 0
+  created_on: <%= 10.days.ago.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 10.days.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Issue due today
+  id: 7
+  fixed_version_id:
+  category_id:
+  description: This is an issue that is due today
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  start_date: <%= 10.days.ago.to_s(:db) %>
+  due_date: <%= Date.today.to_s(:db) %>
+  lock_version: 0
+  root_id: 7
+  lft: 1
+  rgt: 2
+issues_008:
+  position: 0
+  created_on: <%= 10.days.ago.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 10.days.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Closed issue
+  id: 8
+  fixed_version_id:
+  category_id:
+  description: This is a closed issue.
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 5
+  start_date:
+  due_date:
+  lock_version: 0
+  root_id: 8
+  lft: 1
+  rgt: 2
+  closed_on: <%= 3.days.ago.to_s(:db) %>
+issues_009:
+  position: 0
+  created_on: <%= 1.minute.ago.to_s(:db) %>
+  project_id: 5
+  updated_on: <%= 1.minute.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Blocked Issue
+  id: 9
+  fixed_version_id:
+  category_id:
+  description: This is an issue that is blocked by issue #10
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  start_date: <%= Date.today.to_s(:db) %>
+  due_date: <%= 1.days.from_now.to_date.to_s(:db) %>
+  root_id: 9
+  lft: 1
+  rgt: 2
+issues_010:
+  position: 0
+  created_on: <%= 1.minute.ago.to_s(:db) %>
+  project_id: 5
+  updated_on: <%= 1.minute.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Issue Doing the Blocking
+  id: 10
+  fixed_version_id:
+  category_id:
+  description: This is an issue that blocks issue #9
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  start_date: <%= Date.today.to_s(:db) %>
+  due_date: <%= 1.days.from_now.to_date.to_s(:db) %>
+  root_id: 10
+  lft: 1
+  rgt: 2
+issues_011:
+  position: 0
+  created_on: <%= 3.days.ago.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 1.day.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Closed issue on a closed version
+  id: 11
+  fixed_version_id: 1
+  category_id: 1
+  description:
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 5
+  start_date: <%= 1.day.ago.to_date.to_s(:db) %>
+  due_date:
+  root_id: 11
+  lft: 1
+  rgt: 2
+  closed_on: <%= 1.day.ago.to_s(:db) %>
+issues_012:
+  position: 0
+  created_on: <%= 3.days.ago.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 1.day.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Closed issue on a locked version
+  id: 12
+  fixed_version_id: 2
+  category_id: 1
+  description:
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 3
+  status_id: 5
+  start_date: <%= 1.day.ago.to_date.to_s(:db) %>
+  due_date:
+  root_id: 12
+  lft: 1
+  rgt: 2
+  closed_on: <%= 1.day.ago.to_s(:db) %>
+issues_013:
+  position: 0
+  created_on: <%= 5.days.ago.to_s(:db) %>
+  project_id: 3
+  updated_on: <%= 2.days.ago.to_s(:db) %>
+  priority_id: 4
+  subject: Subproject issue two
+  id: 13
+  fixed_version_id:
+  category_id:
+  description: This is a second issue on a cookbook subproject
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  root_id: 13
+  lft: 1
+  rgt: 2
+issues_014:
+  position: 0
+  id: 14
+  created_on: <%= 15.days.ago.to_s(:db) %>
+  project_id: 3
+  updated_on: <%= 15.days.ago.to_s(:db) %>
+  priority_id: 5
+  subject: Private issue on public project
+  fixed_version_id:
+  category_id:
+  description: This is a private issue
+  tracker_id: 1
+  assigned_to_id:
+  author_id: 2
+  status_id: 1
+  is_private: true
+  root_id: 14
+  lft: 1
+  rgt: 2


### PR DESCRIPTION
`rake redmine:plugins:test` fails under the following conditions:

1. `redmine_backlogs` plugin is added.
2. some test exist in **another** plugin

The reason of test failure is because `issues.position` column became NOT NULL [here](https://github.com/maedadev/redmine_backlogs/blob/d68161d8b0048259840f1980529432eb1decb55e/db/migrate/033_unique_positions.rb#L30) while redmine/test/fixtures/issues.yml position column is blank. This potential inconsistency leads test failure when at least one test exists.

(When there is no test, fixtures will not load so that no error happen on `rake redmine:plugins:test`, but it might be rare case.)

This PR overwrites issues.yml to avoid test failure.