### PR TITLE
'project' selection doesn't work on backlog & Task board

### DIFF
--- a/app/views/layouts/rb.html.erb
+++ b/app/views/layouts/rb.html.erb
@@ -14,6 +14,7 @@
 <%= stylesheet_link_tag 'rtl', :media => 'all' if l(:direction) == 'rtl' %>
 <% end %>
 
+<%= javascript_heads %>
 <%= javascript_include_tag 'jquery/jquery-1.7.2-ui-1.8.21-ujs-2.0.3.js', :plugin => 'redmine_backlogs' %>
 
 <%= call_hook :view_layouts_base_html_head %>

--- a/init.rb
+++ b/init.rb
@@ -51,7 +51,7 @@ Redmine::Plugin.register :redmine_backlogs do
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.2.6'
+  version 'v1.2.6.1'
 
   settings :default => {
                          :story_trackers            => nil,


### PR DESCRIPTION
### Issue

'project' select-box located at top-right of screen doesn't work at Backlog & Task board with Redmine ~> v3.4.0 .

### Reason

[Project select box since Redmine v3.4.0](https://www.redmine.org/issues/23310) become nicer by applying Javascript at application.js at the code flagment below:
`  $(".drdn-trigger").click(function(e){...}`
whileBacklog & Task board pages don't call these Javascript part.  That is because project select-box now doesn't work at those pages.

### Solution

Include the Javascript at backlog pages as well.