### PR TITLE
scrollbar is not displayed on browser window at backlog pages

### DIFF
--- a/app/views/layouts/rb.html.erb
+++ b/app/views/layouts/rb.html.erb
@@ -43,6 +43,8 @@ RB.$(function(){
   RB.$('#usability-compat-wrapper').bind('dblclick', function(e,u){
     RB.$('#usability-compat-wrapper').toggleClass('w-rb-header-collapsed');
   });
+
+  $('#wrapper').css('overflow', 'visible');
 });
 
 <%# redmine-core requires the script below %>


### PR DESCRIPTION
## Issue
Redmine_backlogs `backlog` and `task board` pages don't show scrollbar.

![image](https://user-images.githubusercontent.com/50644889/179869042-ce3ab5b2-bba0-4b2a-8fbf-88293ca1cffe.png)

## Reason
Since Redmine 3.3.0, it introduces `overflow: hidden` in page layout [here](https://www.redmine.org/issues/20632).  This impacts backlog pages mentioned above section.

## Solution
Allow `overflow: visible` only for backlog plugin pages; this provides the same situation as redmine < 3.3.0.