### PR TITLE
fix backlog & task-board pages horizontal scroll for redmine >= 4.1.0

### DIFF
--- a/app/views/layouts/rb.html.erb
+++ b/app/views/layouts/rb.html.erb
@@ -56,6 +56,14 @@ function toggleNewObjectDropdown() {
 }
 </script>
 <% end %>
+<style type="text/css">
+  #wrapper {
+    overflow:   visible;
+  }
+  #content {
+    overflow-x: visible;
+  }
+</style>
 </head>
 <body class="<%=h body_css_classes if Backlogs.setting[:show_redmine_std_header] %>">
 <div id="wrapper">

--- a/init.rb
+++ b/init.rb
@@ -52,7 +52,7 @@ Redmine::Plugin.register :redmine_backlogs do
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.3.1'
+  version 'v1.3.2'
 
   settings :default => {
                          :story_trackers            => nil,


### PR DESCRIPTION
## Issue
Redmine_backlogs `backlog` and `task board` pages don't show scrollbar.

![image](https://user-images.githubusercontent.com/50644889/179869042-ce3ab5b2-bba0-4b2a-8fbf-88293ca1cffe.png)

## Reason
1. Since Redmine 3.3.0, it introduces `overflow: hidden` in page layout [here](https://www.redmine.org/issues/20632).  This impacts backlog pages mentioned above section.
1. [Redmine 4.1.0 css change](https://www.redmine.org/issues/30435) also impacts backlog pages horizontal scroll bar strange behavior (2 horizontal bars are shown and slide area is too short).

## Solution
1. Allow `#wrapper {overflow: visible;}` only for backlog plugin pages; this provides the same situation as redmine < 3.3.0 .
1. Unfortunately, above solution is not enough for redmine > 4.1.0 .  `#content {overflow-x: visible;}` is also required.
