### PR TITLE
rollback `.ui-tooltip` css class's `white-space` property only for th=is plugin.

### DIFF
--- a/assets/stylesheets/global.css
+++ b/assets/stylesheets/global.css
@@ -14,6 +14,9 @@ body{
   font-family:Verdana, Arial, sans-serif;
   font-size:12px;
 }
+.ui-tooltip {
+  white-space:  normal;
+}
 a, a:link, a:visited {
   color:#CC0000;
   text-decoration:none;

--- a/init.rb
+++ b/init.rb
@@ -48,11 +48,11 @@ end
 
 
 Redmine::Plugin.register :redmine_backlogs do
-  requires_redmine :version_or_higher => '4.1.0'
+  requires_redmine :version_or_higher => '4.1.5'
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.3.2'
+  version 'v1.3.3'
 
   settings :default => {
                          :story_trackers            => nil,


### PR DESCRIPTION
## Issue
Since Redmine 4.1.5 + `backlogs` plugin, tooltip on task-board page is shown as follows (many line breaks in tooltip):
![image](https://user-images.githubusercontent.com/50644889/180331525-d5133f16-0264-43f7-a370-009470173c4a.png)

## Reason
Redmine 4.1.5 introduces [tooltip line breaks new logic](https://www.redmine.org/issues/34834).  This impacts `backlogs` plugin's tooltip as above.

## Solution
There could be 2 solutions as follows:

- a) change tooltip view template app/views/rb_stories/_tooltip.html.erb to follow new CSS for .ui-tooltip.
- b) rollback .ui-tooltip property only for this plugin.

This PR applies b) above.