### PR TITLE
sort story by issues.subject for each sprint at taskboard page

### DIFF
--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -286,6 +286,14 @@
   <%= check_box_tag("settings[show_project_name]",'enabled',
             Backlogs.setting[:show_project_name]) %>
 </p>
+<p>
+  <%= content_tag(:label, l(:rb_taskboard_view_story_order)) %>
+  <%= select_tag("settings[taskboard_view_story_order]",
+            options_for_select([
+                  [l(:rb_label_taskboard_view_story_order_by_position), 'position'],
+                  [l(:rb_label_taskboard_view_story_order_by_alpha),    'alpha']
+                ], Backlogs.setting[:taskboard_view_story_order])) %>
+</p>
 </fieldset>
 
 <fieldset>

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -106,7 +106,9 @@
   </table>
 
   <table id="tasks" class="board" cellspacing="0">
-    <%- @sprint.stories.each do |story| %>
+    <%- stories = @sprint.stories
+        stories = stories.reorder("issues.subject") if Backlogs.setting[:taskboard_view_story_order] == 'alpha'
+        stories.each do |story| %>
     <tr id="swimlane-<%= story.id %>" class="story-swimlane">
       <td>
         <div class="story <%= mark_if_closed(story) %>" <%= build_inline_style(story).html_safe %>>

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -185,6 +185,8 @@ en-GB:
   rb_label_copy_tasks_none: None
   rb_label_copy_tasks_open: Open
   rb_label_link_to_original: "Include link to original story"
+  rb_label_taskboard_view_story_order_by_position:  "position(default)"
+  rb_label_taskboard_view_story_order_by_alpha:     "alphabetical"
   rb_label_timelog_disable: Disable
   rb_label_timelog_enable: Enable
   rb_project_settings_update_error: "Error while updating settings"
@@ -196,6 +198,7 @@ en-GB:
   rb_task_cards_story_follows_tasks: "Tasks followed by their story"
   rb_task_cards_tasks_follow_story: "Story followed by their tasks"
   rb_taskboard_card_order: "Card print order"
+  rb_taskboard_view_story_order: "Story order on taskboard"
   rb_timelog_from_taskboard: "Timelog from taskboard"
   remaining_story_points: "Remaining story points"
   story_description: Description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,6 +189,8 @@ en:
   rb_label_copy_tasks_none: None
   rb_label_copy_tasks_open: Open
   rb_label_link_to_original: "Include link to original story"
+  rb_label_taskboard_view_story_order_by_position:  "position(default)"
+  rb_label_taskboard_view_story_order_by_alpha:     "alphabetical"
   rb_label_timelog_disable: Disable
   rb_label_timelog_enable: Enable
   rb_project_settings_update_error: "Error while updating settings"
@@ -200,6 +202,7 @@ en:
   rb_task_cards_story_follows_tasks: "Tasks followed by their story"
   rb_task_cards_tasks_follow_story: "Story followed by their tasks"
   rb_taskboard_card_order: "Card print order"
+  rb_taskboard_view_story_order: "Story order on taskboard"
   rb_timelog_from_taskboard: "Timelog from taskboard"
   remaining_story_points: "Remaining story points"
   story_description: Description

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -193,6 +193,8 @@ ja:
   rb_label_copy_tasks_none: なし
   rb_label_copy_tasks_open: 開く
   rb_label_link_to_original: 元のストーリーへのリンクを含める
+  rb_label_taskboard_view_story_order_by_position:  "従来通り(default)"
+  rb_label_taskboard_view_story_order_by_alpha:     "アルファベット順"
   rb_label_timelog_disable: 無効
   rb_label_timelog_enable: 有効
   rb_project_settings_update_error: 失敗しました。
@@ -204,6 +206,7 @@ ja:
   rb_task_cards_story_follows_tasks: ストーリー、タスクの順に印刷
   rb_task_cards_tasks_follow_story: タスク、ストーリーの順に印刷
   rb_taskboard_card_order: カードの印刷順
+  rb_taskboard_view_story_order: "カンバン上のストーリー表示順"
   rb_timelog_from_taskboard: かんばんのタイムログ
   remaining_story_points: 残りのストーリーポイント
   story_description: 説明

--- a/init.rb
+++ b/init.rb
@@ -52,7 +52,7 @@ Redmine::Plugin.register :redmine_backlogs do
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.3.4'
+  version 'v1.4.0'
 
   settings :default => {
                          :story_trackers            => nil,


### PR DESCRIPTION
sort key can be switched by admin > plugins > backlog page.