### PR TITLE
exclude 'closed' versions or releases from droppables

### DIFF
--- a/lib/backlogs_project_patch.rb
+++ b/lib/backlogs_project_patch.rb
@@ -323,6 +323,9 @@ private
               "))" +
           "))" +
           " WHERE pp.lft >= #{r.lft} AND pp.rgt <= #{r.rgt}" +
+                # exclude 'closed' versions or releases.
+                # NOTE: both tables have 'status' column and 'closed' value.
+                " AND drp.status <> 'closed'" +
           " GROUP BY pp.id;"
         sql
       end


### PR DESCRIPTION
### Issue

In lib/backlogs_project_patch.rb, ProjectPatch::InstanceMethods#_sql_for_droppables gather infos of [projects.id, versions/releases ids under the projects], which will be used to check a story can be dragged&dropped on the page.

When the number of versions and/or releases become large, two problems arise:

* A) the SQL takes long time (e.g. 26 seconds under Versions.count ~= 900 and projects.count ~= 240 our case).
* B) In MySQL, [GROUP_CONCAT default max length is 1024 chars](https://dev.mysql.com/doc/refman/5.7/en/aggregate-functions.html#function_group-concat) so that the `_sql_for_droppables` method easily exeeds at our case; the result is chopped so that incorrect value is returned.

### Solution for A

I think the closed versions and releases should be excluded from droppables because they are not used at `backlog` page, am I right?

This PR is for A.

(Solution for B would tune MySQL server parameter or session(SET SESSION group_concat_max_len = ...))