### PR TITLE
Fix bug gnome glabels link broken

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -27,7 +27,7 @@ namespace :redmine do
       puts "Installing to the #{ENV['RAILS_ENV']} environment."
 
       if ! ['no', 'false'].include?("#{ENV['labels']}".downcase)
-        print "Fetching card labels from http://git.gnome.org..."
+        print "Fetching card labels from https://gitlab.gnome.org..."
         STDOUT.flush
         begin
           BacklogsPrintableCards::CardPageLayout.update


### PR DESCRIPTION
* Change the URL for fetching gnome glabels
* Handling 301 redirect when using Net::HTTP
* Fix error uninitialized Prawn::Document::PageGeometry