### PR TITLE
Fix bug tab Backlogs is not displayed in project Settings

### DIFF
--- a/lib/backlogs_projects_helper_patch.rb
+++ b/lib/backlogs_projects_helper_patch.rb
@@ -1,7 +1,7 @@
 require_dependency 'projects_helper'
 
 module BacklogsProjectsHelperPatch
-    def project_settinags_tabs
+    def project_settings_tabs
       tabs = super
       tabs << {:name => 'backlogs',
         :action => :manage_project_backlogs,


### PR DESCRIPTION
Hi @ichylinux 
I find an issue about not displaying tab 'Backlogs' in project Settings page.
It's because of typo in function name.
I fixed it by correcting function name in lib/backlogs_projects_helper_patch.rb