### PR TITLE
Fix bug backlogs plugin fails to display release burn-up chart

### DIFF
--- a/app/models/rb_release.rb
+++ b/app/models/rb_release.rb
@@ -252,8 +252,7 @@ class RbRelease < ActiveRecord::Base
   end
 
   def has_burndown?
-    false #FIXME release burndown broken
-    #return self.stories.size > 0
+    return self.stories.size > 0
   end
 
   def burndown

--- a/lib/backlogs_merged_array.rb
+++ b/lib/backlogs_merged_array.rb
@@ -1,4 +1,4 @@
-module BacklogsMergedArray
+class BacklogsMergedArray
     class FlexObject < Hash
       def initialize(data = {})
         super


### PR DESCRIPTION
Hi @ichylinux 
I fixed an issue about Backlogs fails to display release burn-up chart

Procedure to display release burn-up chart:
1. Go to the plugin's settings page
2. Check the 'Enable release burnup chart (EXPERIMENTAL)' checkbox
3. Open the Releases page
4. Create a release with some issues
5. Click on the created release