### PR TITLE
Fix bug: New Story autofocus not working

### DIFF
--- a/assets/javascripts/backlog.js
+++ b/assets/javascripts/backlog.js
@@ -288,7 +288,7 @@ RB.Backlog = RB.Object.create({
     o.edit();
     story.find('.editor' ).first().focus();
     RB.$('html,body').animate({
-        scrollTop: story.find('.editor').first().offset().top-100
+        scrollTop: story.find('.subject.editor').first().offset().top-100
         }, 200);
   },
   


### PR DESCRIPTION
When the page has too many stories, the new story created is at the bottom of the page, but the page doesn't autoscroll to the bottom.
Fixes this issue by focusing on the input box (similar to New Sprint)  instead of the select box