### PR TITLE
Fix bug: error message is not good when create/update sprint with start date > end date

### DIFF
--- a/app/controllers/rb_sprints_controller.rb
+++ b/app/controllers/rb_sprints_controller.rb
@@ -21,7 +21,12 @@ class RbSprintsController < RbApplicationController
       end
     end
 
-    result = @sprint.save
+    begin
+      result = @sprint.save!
+    rescue => e
+      render :plain => e.message.blank? ? e.to_s : e.message, :status => 400
+      return
+    end
     status = (result ? 200 : 400)
 
     respond_to do |format|
@@ -30,7 +35,12 @@ class RbSprintsController < RbApplicationController
   end
 
   def update
-    result = @sprint.update! rb_sprint_params
+    begin
+      result = @sprint.update! rb_sprint_params
+    rescue => e
+      render :plain => e.message.blank? ? e.to_s : e.message, :status => 400
+      return
+    end
 
     respond_to do |format|
       format.html { render partial: "sprint", status: (result ? 200 : 400), locals: {sprint: @sprint, cls: 'model sprint'} }

--- a/app/models/rb_sprint.rb
+++ b/app/models/rb_sprint.rb
@@ -6,7 +6,7 @@ class RbSprint < Version
   validate :start_and_end_dates
 
   def start_and_end_dates
-    errors.add(:base, "sprint_end_before_start") if self.effective_date && self.sprint_start_date && self.sprint_start_date >= self.effective_date
+    errors.add(:base, I18n.t("error_sprint_end_before_start")) if self.effective_date && self.sprint_start_date && self.sprint_start_date >= self.effective_date
   end
 
   scope :open_sprints, lambda { |project| open_or_locked.by_date.in_project(project) }


### PR DESCRIPTION
When creating/editing a sprint with start_date > end_date , error message is not good.
- Creating a sprint with start_date > end_date, display error message: translation missing: en.error_base sprint_end_before_start
- Editing a sprint with start_date > end_date, display error message: an error occured, please check the server logs (Unprocessable Entity)