### PR TITLE
Fix bug Redmine header content not display completely when not show redmine header in backlogs

### DIFF
--- a/assets/stylesheets/global.css
+++ b/assets/stylesheets/global.css
@@ -29,7 +29,6 @@ a:hover{
   padding: 2px;
   background-color:#CCCCCC;
   display:block;
-  height:30px;
   overflow:hidden;
   position:relative;
   box-shadow: 0 3px 4px #A0A0A0;


### PR DESCRIPTION
On the Backlogs plugin settings page, uncheck Show redmine header in backlogs option.
Check the display of Backlogs screen.
The header content is not displayed completely.
Expected:
![image](https://github.com/maedadev/redmine_backlogs/assets/131934555/8bb9124d-84fd-4307-995d-3cf5ffbdda25)

Actual:
![image](https://github.com/maedadev/redmine_backlogs/assets/131934555/5cf695ee-713a-48cc-adcd-a0f4293e843d)
