### PR TITLE
Validate the Name field value length in 'New release multiview' to be no more than 64 characters as same as 'New release'

### DIFF
--- a/app/models/rb_release_multiview.rb
+++ b/app/models/rb_release_multiview.rb
@@ -6,6 +6,7 @@ class RbReleaseMultiview < ActiveRecord::Base
   serialize :release_ids
 
   validates_presence_of :project_id, :name
+  validates_length_of :name, :maximum => 64
 
   include Backlogs::ActiveRecord::Attributes
 


### PR DESCRIPTION
Currently, if user create new release multiview with a very long name, "Internal Error" page will be displayed.
We update the validation to limit the maximum length of the "Name" field value to 64 characters in the 'New release multiview' page (same as the 'New release' page)