### PR TITLE
Round up the total estimated time of sprint to 2nd decimal place

### DIFF
--- a/app/views/rb_sprints/_sprint.html.erb
+++ b/app/views/rb_sprints/_sprint.html.erb
@@ -6,7 +6,7 @@
 
   <div class="fff-wrapmiddle">
     <div class="fff-middle">
-      <div class="sprint_est_h" style="float:right;line-height:28px">(<%= sprint.estimated_hours.to_f %> est. h)</div>
+      <div class="sprint_est_h" style="float:right;line-height:28px">(<%= sprint.estimated_hours.to_f.round(2) %> est. h)</div>
       <div class="name editable" fieldname="name" fieldlabel="<%=l(:field_name)%>"><%= h sprint.name %></div>
     </div>
   </div>


### PR DESCRIPTION
Hi @ichylinux ,
If a sprint has 1 story with estimated time is 1.3h, the total estimated time of sprint is displayed not good.
![image](https://github.com/maedadev/redmine_backlogs/assets/131934555/a21c999e-d0da-4145-b46d-8c66ca4fa5ad)
Solution: round up the total estimated time of sprint to 2nd decimal place.