### PR TITLE
Add label for Description field in story tooltip to be consistent with other fields

### DIFF
--- a/app/views/rb_stories/_tooltip.html.erb
+++ b/app/views/rb_stories/_tooltip.html.erb
@@ -9,6 +9,6 @@
 <b><%= I18n.t :field_assigned_to %></b>: <%=h assignee_name_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_project %></b>: <%=h project_name_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_release %></b>: <%=h release_or_empty(tooltip) %><br />
-<div><%= textilizable tooltip, :description, :attachments => tooltip.attachments%></div>
+<div><b><%= I18n.t :field_description %></b>: <%= textilizable tooltip, :description, :attachments => tooltip.attachments%></div>
 
 <%=h custom_fields_or_empty(tooltip) %>


### PR DESCRIPTION
Hi @ichylinux 
We add label for Description field in the story tooltip to be consistent with other fields.