### PR TITLE
Limit the maximum sprint length to 3 months 

### DIFF
--- a/app/models/rb_sprint.rb
+++ b/app/models/rb_sprint.rb
@@ -4,9 +4,14 @@ class RbSprint < Version
   unloadable
 
   validate :start_and_end_dates
+  validate :duration_3months
 
   def start_and_end_dates
     errors.add(:base, I18n.t("error_sprint_end_before_start")) if self.effective_date && self.sprint_start_date && self.sprint_start_date >= self.effective_date
+  end
+
+  def duration_3months
+    errors.add(:base, I18n.t('error_sprint_duration_maximum_three_months')) if self.effective_date && self.sprint_start_date && self.effective_date > self.sprint_start_date + 3.months
   end
 
   scope :open_sprints, lambda { |project| open_or_locked.by_date.in_project(project) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,3 +228,4 @@ en:
       * State will be set to the default issue state
   error_cannot_close_sprint_with_open_stories: "Cannot close a sprint while it still has open stories."
   error_task_not_exist: "This task has already been deleted and no longer exists."
+  error_sprint_duration_maximum_three_months: "The maximum duration of a sprint is 3 months."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -230,3 +230,4 @@ ja:
       * ステータスはチケットのデフォルトのステータスになります
   error_cannot_close_sprint_with_open_stories: "オープン中のストーリーが存在するためストーリーを閉じることができません"
   error_task_not_exist: "タスクは既に削除されており、存在しません。"
+  error_sprint_duration_maximum_three_months: "スプリントの長さは最長3ヶ月までです。"


### PR DESCRIPTION
The current UI allows the user to set unrealistically long sprint durations, e.g. 10 years.
When the user sets such a long duration, it is mostly by a mistake
But it causes the backlogs plugin to throw errors:

> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] Started GET "/redmine/rb/burndown/6/embed" for 172.17.0.1 at 2023-10-04 03:27:47 +0000
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] Processing by RbBurndownChartsController#embedded as HTML
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]   Parameters: {"sprint_id"=>"6"}
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]   Current user: admin (id=1)
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]   Rendered plugins/redmine_backlogs/app/views/rb_burndown_charts/show.html.erb (Duration: 740.2ms | Allocations: 448897)
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] Completed 500 Internal Server Error in 766ms (ActiveRecord: 22.2ms | Allocations: 452001)
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]   
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] ActionView::Template::Error (Mysql2::Error: Data too long for column 'burndown' at row 1):
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     13: <script type="text/javascript" language="javascript">
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     14:   <%-
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     15:       burndown = sprint.burndown
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     16:       series = burndown.series.sort{|a, b| l("label_#{a}") <=> l("label_#{b}") }
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     17:       dates = sprint.days
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     18: 
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]     19:       tz = RbIssueHistory.burndown_timezone
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75]   
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/models/rb_sprint_burndown.rb:140:in `get_burndown'
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/models/rb_sprint_burndown.rb:49:in `series'
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/views/rb_burndown_charts/_burndown.html.erb:16
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/views/rb_burndown_charts/show.html.erb:3
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/controllers/rb_burndown_charts_controller.rb:14:in `block (2 levels) in embedded'
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] plugins/redmine_backlogs/app/controllers/rb_burndown_charts_controller.rb:13:in `embedded'
> App 300 output: [3c6d2fb8-f3c0-4e6f-b764-99a1acd54c75] lib/redmine/sudo_mode.rb:61:in `sudo_mode'

And burndown chart cannot be displayed:
![image](https://github.com/maedadev/redmine_backlogs/assets/131934555/aaca3326-f9c4-4fb8-91f6-52a7ded0dd3d)

Therefore, we limit the maximum sprint length to 3 months to prevent error when display burndown chart of sprint with unrealistically long sprint duration:
![image](https://github.com/maedadev/redmine_backlogs/assets/131934555/dc422cee-a011-4a2d-b99c-40fc74c988a9)

