### PR TITLE
fix: SQL crash when position is not defined

### DIFF
--- a/lib/backlogs/active_record/list_with_gaps.rb
+++ b/lib/backlogs/active_record/list_with_gaps.rb
@@ -121,7 +121,9 @@ module Backlogs
       end
 
       def list_commit
-        self.class.connection.execute("update #{self.class.table_name} set position = #{self.position} where id = #{self.id}") unless self.new_record?
+		if (self.position)
+        	self.class.connection.execute("update #{self.class.table_name} set position = #{self.position} where id = #{self.id}") unless self.new_record?
+		end
         #FIXME now the cached lower/higher_item are wrong during this request. So are those from our old and new peers.
       end
 


### PR DESCRIPTION
Don't have enough knowledge to Redmine nor Backlogs, so this probably hides something else…

I faced a SQL crash when updating a ticket:

```sql
update issues set position =  where id = 6759
```

Associated logs:

```
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a] Completed 500 Internal Server Error in 429ms (ActiveRecord: 93.3ms | Allocations: 116321)
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a]   
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a] ActiveRecord::StatementInvalid (Mysql2::Error: You have an error in your SQL syntax; check the m
anual that corresponds to your MariaDB server version for the right syntax to use near 'where id = 6759' at line 1):
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a]   
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a] plugins/redmine_backlogs/lib/backlogs/active_record/list_with_gaps.rb:124:in `list_commit'
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a] plugins/redmine_backlogs/lib/backlogs/active_record/list_with_gaps.rb:37:in `move_to_top'
App 679060 stderr: [253a78c9-02c9-4633-b0d3-f58cb723771a] plugins/redmine_backlogs/lib/backlogs_issue_patch.rb:133:in `backlogs_before_save'
```

Changes in this PR ensure that request is not executed when `position` is undefined.