### PR TITLE
support before ruby3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
-gem "sidekiq"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
+  gem 'sidekiq', '< 8.0'
+else
+  gem 'sidekiq'
+end
 gem 'erubis', '~> 2.7'
 gem "holidays", "~>1.0.3"
 gem "icalendar"


### PR DESCRIPTION
sidekiq 8 and above requires Ruby 3.  
We've made support for versions before Ruby 3. 