### PR TITLE
Replaced ActiveSupport::Reloader.to_prepare

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -10,7 +10,7 @@ if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
   end
   require_relative 'lib/backlogs/active_record/list_with_gaps'
   require_relative 'lib/backlogs_version_patch'
-  ActiveSupport::Reloader.to_prepare do
+  Rails.application.config.after_initialize do
     require_relative 'lib/backlogs_nested_set_patch'
     require_relative 'lib/backlogs/active_record'
     require_relative 'lib/backlogs/active_record/attributes'


### PR DESCRIPTION
Switched from ActiveSupport::Reloader.to_prepare and Rails.application.reloader.to_prepare to Rails.application.config.after_initialize because to_prepare is not reliably called in Redmine 5.x and later.
See https://www.redmine.org/issues/36245#note-11 for details.